### PR TITLE
fix: Deduplicate entries

### DIFF
--- a/node_stream_zip.js
+++ b/node_stream_zip.js
@@ -369,7 +369,7 @@ const StreamZip = function (config) {
                 if (!config.skipEntryNameValidation) {
                     entry.validateName();
                 }
-                if (entries) {
+                if (!entries[entry.name] || entry.headerOffset > entries[entry.name].headerOffset) {
                     entries[entry.name] = entry;
                 }
                 that.emit('entry', entry);

--- a/node_stream_zip.js
+++ b/node_stream_zip.js
@@ -369,7 +369,7 @@ const StreamZip = function (config) {
                 if (!config.skipEntryNameValidation) {
                     entry.validateName();
                 }
-                if (!entries[entry.name] || entry.headerOffset > entries[entry.name].headerOffset) {
+                if (entries && !(entry.name in entries)) {
                     entries[entry.name] = entry;
                 }
                 that.emit('entry', entry);


### PR DESCRIPTION
This will keep the first entry in the zip if there are multiple entries with same path/name